### PR TITLE
27 naa expunge request which need to be folded into our updated pipeline eventually

### DIFF
--- a/python_scripts/repeatable/suppress_objects.py
+++ b/python_scripts/repeatable/suppress_objects.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python3
+# This script takes a CSV file containing the URIs of resources to suppress in the ArchivesSpace staff interface,
+# unpublish and set the finding aid status to staff only. The CSV should have a header row that reads "URI". The
+# script takes the CSV, splits the URI into the ArchivesSpace resource ID, grabs the resource JSON data,
+# then passes the data to the update_publish_status function, which modifies the JSON to publish=False and
+# finding_aid_status=staff_only. Then it posts the updated JSON to ArchivesSpace and suppresses the record.
+import argparse
+import os
+import sys
+
+from copy import deepcopy
+from dotenv import load_dotenv, find_dotenv
+from loguru import logger
+from pathlib import Path
+
+sys.path.append(os.path.dirname('python_scripts'))  # Needed to import functions from utilities.py
+from python_scripts.utilities import ASpaceAPI, read_csv, record_error
+
+logger.remove()
+log_path = Path('../logs', 'suppress_resources_{time:YYYY-MM-DD}.log')
+logger.add(str(log_path), format="{time}-{level}: {message}")
+
+# Find  and load environment-specific .env file
+env_file = find_dotenv(f'.env.{os.getenv("ENV", "dev")}')
+load_dotenv(env_file)
+
+def parseArguments():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("csvPath", help="path to csv input file", type=str)
+    parser.add_argument("repoID", help="the ASpace repo id number", type=int)
+    parser.add_argument("objectType", help="resources/archival_objects/digital_objects", type=str)
+    parser.add_argument("-dR", "--dry-run", help="dry run?", action='store_true')
+    parser.add_argument("--version", action="version", version='%(prog)s - Version 1.0')
+
+    return parser.parse_args()
+
+
+def update_publish_status(object_json, object_type):
+    """
+
+    Args:
+        object_json (dict): the JSON data of the object we want to unpublish and set FA status to staff_only if resource
+        object_type (str): the object type to update: resources, archival_objects, digital_objects
+
+    Returns:
+        updated_json (dict): the JSON data of the resource updated with publish=False and finding_aid_status=staff_only
+    """
+    acceptable_types = ['resources', 'archival_objects', 'digital_objects']
+    if object_type not in acceptable_types:
+        record_error(f'update_publish_status() - provided object type is not in {acceptable_types}',
+                     ValueError)
+    else:
+        updated_object = deepcopy(object_json)
+        if object_type == "resources":
+            updated_object["finding_aid_status"] = 'staff_only'
+        updated_object["publish"] = False
+        return updated_object
+
+
+def main(csv_location, repo_id=None, object_type=None, dry_run=False):
+    """
+    Takes a CSV of resource URIs, searches for them in ArchivesSpace, then suppresses the resources using the API
+
+    Args:
+        csv_location (str): filepath of the CSV containing the location URIs to update
+        repo_id (int): repository ID if the CSV does not contain the repository ID within the object URI
+        object_type (str): the type of object you want to suppress: resources, archival_objects, digital_objects
+        dry_run (bool): if True, do not suppress resources. Just print statements confirming the resources to suppress
+    """
+    local_aspace = ASpaceAPI(os.getenv('as_api'), os.getenv('as_un'), os.getenv('as_pw'))
+    uris = read_csv(str(Path(os.getcwd(), csv_location)))
+    for row in uris:
+        object_uri_parts = list(filter(None, row['URL'].split('/')))  # Filter out any empty strings
+        try:
+            resource_aspace_id = int(object_uri_parts[-1])
+        except ValueError:  # If anything other than an integer in the ASpace generated object ID, then throw error
+            record_error(f'main() - error getting object ID {object_uri_parts[-1]}', ValueError)
+        else:
+            if repo_id is None:
+                repo_id = object_uri_parts[1]
+            if object_type is None:
+                object_type = object_uri_parts[2]
+            original_object = local_aspace.get_object('resources',
+                                                        resource_aspace_id,
+                                                        f'repositories/{repo_id}/')
+            if original_object:
+                updated_object = update_publish_status(original_object, object_type)
+                if dry_run is True:
+                    print(f'This is what the post will look like: {updated_object}')
+                else:
+                    update_status = local_aspace.update_object(row['uri'], updated_object)
+                    if update_status is not None:
+                        local_aspace.update_suppression(updated_object['uri'], True)
+
+
+if __name__ == '__main__':
+    args = parseArguments()
+
+    # Print arguments
+    logger.info(f'Running {sys.argv[0]} script with following arguments: ')
+    print(f'Running {sys.argv[0]} script with following arguments: ')
+    for arg in args.__dict__:
+        logger.info(str(arg) + ": " + str(args.__dict__[arg]))
+        print(str(arg) + ": " + str(args.__dict__[arg]))
+
+    # Run function
+    main(args.csvPath, args.repoID, args.objectType, args.dry_run)

--- a/python_scripts/repeatable/suppress_objects.py
+++ b/python_scripts/repeatable/suppress_objects.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python3
-# This script takes a CSV file containing the URIs of resources to suppress in the ArchivesSpace staff interface,
-# unpublish and set the finding aid status to staff only. The CSV should have a header row that reads "URI". The
-# script takes the CSV, splits the URI into the ArchivesSpace resource ID, grabs the resource JSON data,
-# then passes the data to the update_publish_status function, which modifies the JSON to publish=False and
+# This script takes a CSV file containing the URIs or URLs of objects to suppress in the ArchivesSpace staff interface,
+# unpublish and set the finding aid status to staff only (for resources). The CSV should have a header row that reads
+# "URI", and you can pass the object's repository identifier number and object type (resources, archival_objects,
+# digital_objects) as script arguments. The script takes the CSV, splits the URI into the ArchivesSpace resource ID,
+# repository ID (if not already supplied) and object type (if not already supplied), grabs the resource JSON data, then
+# passes the data to the update_publish_status function, which modifies the JSON to publish=False and
 # finding_aid_status=staff_only. Then it posts the updated JSON to ArchivesSpace and suppresses the record.
 import argparse
 import os
@@ -60,7 +62,8 @@ def update_publish_status(object_json, object_type):
 
 def main(csv_location, repo_id=None, object_type=None, dry_run=False):
     """
-    Takes a CSV of resource URIs, searches for them in ArchivesSpace, then suppresses the resources using the API
+    Takes a CSV of object URIs or URLs, searches for them in ArchivesSpace, then unpublishes, suppresses, and sets the
+    finding_aid_status if resource to staff_only using the API
 
     Args:
         csv_location (str): filepath of the CSV containing the location URIs to update
@@ -81,9 +84,9 @@ def main(csv_location, repo_id=None, object_type=None, dry_run=False):
                 repo_id = object_uri_parts[1]
             if object_type is None:
                 object_type = object_uri_parts[2]
-            original_object = local_aspace.get_object('resources',
-                                                        resource_aspace_id,
-                                                        f'repositories/{repo_id}/')
+            original_object = local_aspace.get_object(object_type,
+                                                      resource_aspace_id,
+                                                      f'repositories/{repo_id}')
             if original_object:
                 updated_object = update_publish_status(original_object, object_type)
                 if dry_run is True:

--- a/python_scripts/repeatable/suppress_objects.py
+++ b/python_scripts/repeatable/suppress_objects.py
@@ -17,7 +17,7 @@ sys.path.append(os.path.dirname('python_scripts'))  # Needed to import functions
 from python_scripts.utilities import ASpaceAPI, read_csv, record_error
 
 logger.remove()
-log_path = Path('../logs', 'suppress_resources_{time:YYYY-MM-DD}.log')
+log_path = Path('../logs', 'suppress_objects_{time:YYYY-MM-DD}.log')
 logger.add(str(log_path), format="{time}-{level}: {message}")
 
 # Find  and load environment-specific .env file
@@ -89,9 +89,14 @@ def main(csv_location, repo_id=None, object_type=None, dry_run=False):
                 if dry_run is True:
                     print(f'This is what the post will look like: {updated_object}')
                 else:
-                    update_status = local_aspace.update_object(row['uri'], updated_object)
+                    update_status = local_aspace.update_object(updated_object['uri'], updated_object)
                     if update_status is not None:
-                        local_aspace.update_suppression(updated_object['uri'], True)
+                        print(update_status)
+                        logger.info(update_status)
+                        suppress_message = local_aspace.update_suppression(updated_object['uri'], True)
+                        if suppress_message is not None:
+                            print(suppress_message)
+                            logger.info(suppress_message)
 
 
 if __name__ == '__main__':

--- a/python_scripts/repeatable/suppress_objects.py
+++ b/python_scripts/repeatable/suppress_objects.py
@@ -1,11 +1,12 @@
 #!/usr/bin/python3
 # This script takes a CSV file containing the URIs or URLs of objects to suppress in the ArchivesSpace staff interface,
-# unpublish and set the finding aid status to staff only (for resources). The CSV should have a header row that reads
+# unpublishes and sets the finding aid status to staff only (for resources). The CSV should have a header row that reads
 # "URI", and you can pass the object's repository identifier number and object type (resources, archival_objects,
 # digital_objects) as script arguments. The script takes the CSV, splits the URI into the ArchivesSpace resource ID,
 # repository ID (if not already supplied) and object type (if not already supplied), grabs the resource JSON data, then
 # passes the data to the update_publish_status function, which modifies the JSON to publish=False and
-# finding_aid_status=staff_only. Then it posts the updated JSON to ArchivesSpace and suppresses the record.
+# finding_aid_status=staff_only (for resources only). Then it posts the updated JSON to ArchivesSpace and suppresses
+# the record.
 import argparse
 import os
 import sys

--- a/python_scripts/utilities.py
+++ b/python_scripts/utilities.py
@@ -100,10 +100,13 @@ class ASpaceAPI:
         try:
             object_json = self.aspace_client.get(f'{repo_uri}/{record_type}/{object_id}').json()
         except HTTPException as get_error:
-            record_error('get_object() - Unable to retrieve object', get_error)
+            record_error(f'get_object() - Unable to retrieve object {repo_uri}/{record_type}/{object_id}',
+                         get_error)
         else:
             if 'error' in object_json:
-                record_error('get_object() - Unable to retrieve object with provided URI', object_json)
+                record_error(f'get_object() - Unable to retrieve object with provided URI: '
+                             f'{repo_uri}/{record_type}/{object_id}',
+                             object_json)
             else:
                 return object_json
 
@@ -121,8 +124,26 @@ class ASpaceAPI:
         update_message = self.aspace_client.post(f'{object_uri}', json=updated_json).json()
         if 'error' in update_message:
             record_error('update_object() - Update failed due to following error', update_message)
-            return None
-        return update_message
+        else:
+            return update_message
+
+    def update_suppression(self, object_uri, suppression):
+        """
+        Suppresses or unsuppresses the given object_uri in ArchivesSpace
+
+        Args:
+            object_uri (str): the original object's URI for posting to the client
+            suppression (bool): to suppress the object, set to True. To unsuppress, set to False
+
+        Returns:
+            update_message (dict): ArchivesSpace response or None if an error was encountered and logged
+        """
+        suppress_message = self.aspace_client.post(f'{object_uri}/suppressed',
+                                                   params={"suppressed": suppression}).json()
+        if 'error' in suppress_message:
+            record_error('update_suppression() - Suppression failed due to following error', suppress_message)
+        else:
+            return suppress_message
 
 
 class ASpaceDatabase:

--- a/test_data/suppressobjects_testdata.py
+++ b/test_data/suppressobjects_testdata.py
@@ -1,0 +1,87 @@
+published_resource = {
+  "lock_version": 12,
+  "title": "test collection for suppress_resources",
+  "publish": True,
+  "restrictions": False,
+  "ead_id": "test_suppress_resources_001",
+  "created_by": "admin",
+  "last_modified_by": "sanchezgl",
+  "create_time": "2018-09-26T21:00:24Z",
+  "system_mtime": "2024-11-18T16:31:15Z",
+  "user_mtime": "2024-09-17T16:57:11Z",
+  "suppressed": False,
+  "is_slug_auto": False,
+  "id_0": "test_collection",
+  "level": "collection",
+  "finding_aid_language": "eng",
+  "finding_aid_script": "Latn",
+  "finding_aid_status": "publish",
+  "jsonmodel_type": "resource",
+  "linked_events": [],
+  "extents": [
+    {
+      "lock_version": 0,
+      "number": "6",
+      "created_by": "sanchezgl",
+      "last_modified_by": "sanchezgl",
+      "create_time": "2024-09-17T16:57:11Z",
+      "system_mtime": "2024-09-17T16:57:11Z",
+      "user_mtime": "2024-09-17T16:57:11Z",
+      "portion": "part",
+      "extent_type": "pages",
+      "jsonmodel_type": "extent"
+    }
+  ],
+  "lang_materials": [
+    {
+      "lock_version": 0,
+      "created_by": "sanchezgl",
+      "last_modified_by": "sanchezgl",
+      "create_time": "2024-09-17T16:57:11Z",
+      "system_mtime": "2024-09-17T16:57:11Z",
+      "user_mtime": "2024-09-17T16:57:11Z",
+      "jsonmodel_type": "lang_material",
+      "notes": [],
+      "language_and_script": {
+        "lock_version": 0,
+        "created_by": "sanchezgl",
+        "last_modified_by": "sanchezgl",
+        "create_time": "2024-09-17T16:57:11Z",
+        "system_mtime": "2024-09-17T16:57:11Z",
+        "user_mtime": "2024-09-17T16:57:11Z",
+        "language": "und",
+        "jsonmodel_type": "language_and_script"
+      }
+    }
+  ],
+  "dates": [
+    {
+      "lock_version": 0,
+      "expression": "March, 1861",
+      "created_by": "sanchezgl",
+      "last_modified_by": "sanchezgl",
+      "create_time": "2024-09-17T16:57:11Z",
+      "system_mtime": "2024-09-17T16:57:11Z",
+      "user_mtime": "2024-09-17T16:57:11Z",
+      "date_type": "inclusive",
+      "label": "creation",
+      "era": "ce",
+      "jsonmodel_type": "date"
+    }
+  ],
+  "external_documents": [],
+  "rights_statements": [],
+  "import_previous_arks": [],
+  "revision_statements": [],
+  "instances": [],
+  "deaccessions": [],
+  "related_accessions": [],
+  "content_warnings": [],
+  "uri": "/repositories/27/resources/24917",
+  "repository": {
+    "ref": "/repositories/27"
+  },
+  "tree": {
+    "ref": "/repositories/27/resources/24917/tree"
+  }
+}

--- a/tests/suppressobjects_tests.py
+++ b/tests/suppressobjects_tests.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+
 # This script contains unittests for suppress_objects.py
 import contextlib
 import io
@@ -26,3 +27,5 @@ class TestUpdatePublishStatus(unittest.TestCase):
         self.assertTrue(
             r"""update_publish_status() - provided object type is not in ['resources', 'archival_objects', 'digital_objects']: <class 'ValueError'>""" in f.getvalue())
 
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/suppressobjects_tests.py
+++ b/tests/suppressobjects_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# This script contains unittests for update_locations.py
+# This script contains unittests for suppress_objects.py
 import contextlib
 import io
 import unittest

--- a/tests/suppressobjects_tests.py
+++ b/tests/suppressobjects_tests.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python3
+# This script contains unittests for update_locations.py
+import contextlib
+import io
+import unittest
+
+from python_scripts.repeatable.suppress_objects import *
+from test_data.suppressobjects_testdata import *
+
+
+class TestUpdatePublishStatus(unittest.TestCase):
+
+    def test_good_update(self):
+        """Tests that a provided resource has it's publish and finding_aid_status fields updated"""
+        updated_resource = update_publish_status(published_resource, "resources")
+        self.assertEqual(updated_resource['publish'], False)
+        self.assertEqual(updated_resource['finding_aid_status'], "staff_only")
+
+    def test_bad_type(self):
+        """Tests inputting a bad object type that isn't in the list of resources, archival_objects, or
+        digital_objects"""
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            update_publish_status(published_resource, "laksdjflkj")
+
+        self.assertTrue(
+            r"""update_publish_status() - provided object type is not in ['resources', 'archival_objects', 'digital_objects']: <class 'ValueError'>""" in f.getvalue())
+


### PR DESCRIPTION
## Description
This script takes a CSV file containing the URIs or URLs of objects to suppress in the ArchivesSpace staff interface, unpublishes and sets the finding aid status to staff only (for resources). The CSV should have a header row that reads "URI", and you can pass the object's repository identifier number and object type (resources, archival_objects, digital_objects) as script arguments. The script takes the CSV, splits the URI into the ArchivesSpace resource ID, repository ID (if not already supplied) and object type (if not already supplied), grabs the resource JSON data, then passes the data to the update_publish_status function, which modifies the JSON to publish=False and finding_aid_status=staff_only (for resources only). Then it posts the updated JSON to ArchivesSpace and suppresses the record.

Also added is the update_suppression function in utilities.py, which suppresses or unsuppresses the given object_uri in ArchivesSpace.

## Related GitHub Issue
#27 and #29 

## Testing
- suppressobjects_tests.py and suppressobjects_testdata.py
- Added 3 new tests in utilities_tests.py for testing update_suppression 

## Screenshot(s):


## Checklist

- [X] ✔️ Have you assigned at least one reviewer?
- [X] 🔗 Have you referenced any issues this PR will close?
- [X] ⬇️ Have you merged the latest upstream changes into your branch? 
- [X] 🧪 Have you added tests to cover these changes?  If not, why:

[//]: # (- [ ] 🤖 Have automated checks &#40;if any&#41; passed?  If not, please explain for the reviewer:)
No automated tests yet. We will be looking to automate the linting process in the future, as well as any other tests that can be automated.
- [ ] 📘 Have you updated/added any relevant readmes/wiki pages/comments in the codebase?
- [X] 📚 Have you updated/added any external documentation (e.g. Confluence, AirTable, GitHub Projects)?
