### PR TITLE
28 use statement

### DIFF
--- a/python_scripts/repeatable/update_fileuri.py
+++ b/python_scripts/repeatable/update_fileuri.py
@@ -59,6 +59,10 @@ def build_digital_object(do, new_uri):
     Returns:
         do (dict): updated digital object ready to post to ArchivesSpace
     """
+    if do['file_versions'][0]['file_uri'].endswith('.pdf'):
+        do['file_versions'][0]['use_statement'] = 'application-pdf'
+    if do['file_versions'][0]['file_uri'].endswith('.mp3'):
+        do['file_versions'][0]['use_statement'] = 'audio-service'
     do['file_versions'][0]['file_uri'] = new_uri
 
     return do

--- a/test_data/fileuri_testdata.py
+++ b/test_data/fileuri_testdata.py
@@ -1,0 +1,56 @@
+test_update_file_uri_metadata = {
+    'lock_version': 0,
+    'digital_object_id': '1234567',
+    'title': 'Test digital object',
+    'publish': False,
+    'jsonmodel_type': 'digital_object',
+    'file_versions': [
+        {
+            'lock_version': 0,
+            'file_uri': 'https://mads.si.edu/mads/view/ACM-AV005265',
+            'jsonmodel_type': 'file_version'
+        }
+    ],
+    'uri': '/repositories/2/digital_objects/1',
+    'repository': {
+        'ref': '/repositories/2'
+    }
+}
+
+test_update_file_uri_metadata_pdf = {
+    'lock_version': 0,
+    'digital_object_id': '1234567',
+    'title': 'Test digital object',
+    'publish': False,
+    'jsonmodel_type': 'digital_object',
+    'file_versions': [
+        {
+            'lock_version': 0,
+            'file_uri': 'https://si.edu/media/CFCH/CFCH-FESTBK2013.pdf',
+            'jsonmodel_type': 'file_version'
+        }
+    ],
+    'uri': '/repositories/2/digital_objects/1',
+    'repository': {
+        'ref': '/repositories/2'
+    }
+}
+
+test_update_file_uri_metadata_mp3 = {
+    'lock_version': 0,
+    'digital_object_id': '1234567',
+    'title': 'Test digital object',
+    'publish': False,
+    'jsonmodel_type': 'digital_object',
+    'file_versions': [
+        {
+            'lock_version': 0,
+            'file_uri': 'https://www.si.edu/media/ACM/ACM-AV005265.mp3',
+            'jsonmodel_type': 'file_version'
+        }
+    ],
+    'uri': '/repositories/2/digital_objects/1',
+    'repository': {
+        'ref': '/repositories/2'
+    }
+}

--- a/test_data/updatefileuri_testdata.csv
+++ b/test_data/updatefileuri_testdata.csv
@@ -1,0 +1,2 @@
+digital_object_id,repo_id,updated_file_uri
+2,2,https://mads.si.edu/mads/id/NASM-Young_interview_transcript_mwaohi_NASM.2020.0005

--- a/tests/updatefileuri_tests.py
+++ b/tests/updatefileuri_tests.py
@@ -1,4 +1,4 @@
-# This script consists of unittests for merge_subjects.py
+# This script consists of unittests for update_fileuri.py
 import unittest
 
 from python_scripts.repeatable.update_fileuri import *
@@ -33,6 +33,20 @@ class TestBuildDigitalObject(unittest.TestCase):
         for row in test_dos:
             updated_do = build_digital_object(test_update_file_uri_metadata, row['updated_file_uri'])
             self.assertEqual(row['updated_file_uri'], updated_do['file_versions'][0]['file_uri'])
+
+    def test_build_digital_object_pdf(self):
+        """Tests that the digital object is built as expected when a pdf"""
+        test_dos = read_csv(str(Path(f'./test_data/updatefileuri_testdata.csv')))
+        for row in test_dos:
+            updated_do = build_digital_object(test_update_file_uri_metadata_pdf, row['updated_file_uri'])
+            self.assertEqual('application-pdf', updated_do['file_versions'][0]['use_statement'])
+
+    def test_build_digital_object_mp3(self):
+        """Tests that the digital object is built as expected when a mp3"""
+        test_dos = read_csv(str(Path(f'./test_data/updatefileuri_testdata.csv')))
+        for row in test_dos:
+            updated_do = build_digital_object(test_update_file_uri_metadata_mp3, row['updated_file_uri'])
+            self.assertEqual('audio-service', updated_do['file_versions'][0]['use_statement'])
 
 class TestDigitalObjects(unittest.TestCase):
 


### PR DESCRIPTION
## Description
Adds logic to update the file_uri use statement based on the old-style link's file extension as described in the linked issue.

This was run against ASpace02 on 3/4/25.

## Related GitHub Issue
Closes #28 

## Testing
Tests added and passing.

## Screenshot(s):


## Checklist

- [x] ✔️ Have you assigned at least one reviewer?
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
- [x] 📘 Have you updated/added any relevant readmes/wiki pages/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence, AirTable, GitHub Projects)?
