### PR TITLE
100 project request delete duplicate locations for nmah

### DIFF
--- a/python_scripts/repeatable/delete_objects.py
+++ b/python_scripts/repeatable/delete_objects.py
@@ -1,11 +1,6 @@
 #!/usr/bin/python3
-# This script takes a CSV of URIs and object type as inputs, grabs all the locations' JSON data using the API, saves
-# them to a jsonL file using the jsonl_path input, and then deletes them in ArchivesSpace. It's recommended to check to
-# see if locations have any top containers associated with them. You can run an SQL query to find any associated top
-# containers such as the following:
-# SELECT * FROM top_container_housed_at_rlshp
-# WHERE
-# location_id in (49324,49338,49323,etc.)
+# This script takes a CSV of URIs and object type as inputs, grabs all the objects' JSON data using the API, saves
+# them to a jsonL file using the jsonl_path input, and then deletes them in ArchivesSpace.
 import argparse
 import os
 import sys
@@ -14,11 +9,13 @@ from dotenv import load_dotenv, find_dotenv
 from loguru import logger
 from pathlib import Path
 
+from python_scripts.one_time_scripts.delete_dometadata import record_error
+
 sys.path.append(os.path.dirname('python_scripts'))  # Needed to import functions from utilities.py
 from python_scripts.utilities import ASpaceAPI, read_csv, write_to_file
 
 logger.remove()
-log_path = Path('../../logs', 'delete_locations_{time:YYYY-MM-DD}.log')
+log_path = Path('../../logs', 'delete_objects_{time:YYYY-MM-DD}.log')
 logger.add(str(log_path), format="{time}-{level}: {message}")
 
 # Find  and load environment-specific .env file
@@ -31,16 +28,39 @@ def parseArguments():
 
     parser.add_argument("csvPath", help="path to CSV input file", type=str)
     parser.add_argument("jsonPath", help="path to the JSONL file for storing data", type=str)
-    parser.add_argument("objectType", help="resources/archival_objects/digital_objects", type=str)
     parser.add_argument("-dR", "--dry-run", help="dry run?", action='store_true')
     parser.add_argument("--version", action="version", version='%(prog)s - Version 1.0')
 
     return parser.parse_args()
 
-
-def main(csv_path, jsonl_path, objectType, dry_run=False):
+def retrieve_object_json(object_uri, local_aspace):
     """
-    This script takes a CSV of URIs and object type as inputs, grabs all the locations' JSON data using the API, saves
+    Splits the given URI for the object via / and retrieves the object's JSON.
+    Args:
+        object_uri (DictReader object): the URI of the object
+        local_aspace (ASpaceAPI object): an instance of the ASpace API for connecting to the client
+
+    Returns:
+        object_json (dict): the JSON metadata for the object URI
+    """
+    try:
+        uri_parts = object_uri['uri'].split('/')
+        object_type, object_id = uri_parts[-2], uri_parts[-1]
+    except IndexError as spliterror:
+        record_error(f'retrieve_object_json() - Failed to split URI', spliterror)
+        return None
+    else:
+        if "repositories" in uri_parts:
+            repo_uri = f'repositories/{uri_parts[2]}'
+            object_json = local_aspace.get_object(object_type, object_id, repo_uri)
+        else:
+            object_json = local_aspace.get_object(object_type, object_id)
+        return object_json
+
+
+def main(csv_path, jsonl_path, dry_run=False):
+    """
+    This script takes a CSV of URIs and object type as inputs, grabs all the objects' JSON data using the API, saves
     them to a jsonL file using the jsonl_path input, and then deletes them in ArchivesSpace.
 
     The CSV should have the following data structure:
@@ -48,21 +68,19 @@ def main(csv_path, jsonl_path, objectType, dry_run=False):
     - Column 1 rows = /locations/#######
 
     Args:
-        csv_path (str): filepath of the CSV file with the location URIs
+        csv_path (str): filepath of the CSV file with the object URIs
         jsonl_path (str): filepath of the jsonL file for storing JSON data of objects before updates - backup
-        objectType (str): the type of object you want to delete. resources/archival_objects/digital_objects/locations
         dry_run (bool): if True, it prints the changed object_json but does not post the changes to ASpace
     """
     local_aspace = ASpaceAPI(os.getenv('as_api'), os.getenv('as_un'), os.getenv('as_pw'))
     for uri in read_csv(csv_path):
-        uri_parts = uri['uri'].split('/')
-        location = local_aspace.get_object(objectType, uri_parts[2])
-        write_to_file(jsonl_path, location)
-        if location:
+        object_json = retrieve_object_json(uri, local_aspace)
+        write_to_file(jsonl_path, object_json)
+        if object_json:
             if dry_run:
-                print(f'Deleted location {uri['uri']}')
+                print(f'Deleted object {uri['uri']}')
             else:
-                post_response = local_aspace.delete_object(location['uri'])
+                post_response = local_aspace.delete_object(object_json['uri'])
                 if post_response:
                     print(post_response)
 

--- a/python_scripts/repeatable/delete_objects.py
+++ b/python_scripts/repeatable/delete_objects.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python3
+# This script takes a CSV of URIs and object type as inputs, grabs all the locations' JSON data using the API, saves
+# them to a jsonL file using the jsonl_path input, and then deletes them in ArchivesSpace. It's recommended to check to
+# see if locations have any top containers associated with them. You can run an SQL query to find any associated top
+# containers such as the following:
+# SELECT * FROM top_container_housed_at_rlshp
+# WHERE
+# location_id in (49324,49338,49323,etc.)
+import argparse
+import os
+import sys
+
+from dotenv import load_dotenv, find_dotenv
+from loguru import logger
+from pathlib import Path
+
+sys.path.append(os.path.dirname('python_scripts'))  # Needed to import functions from utilities.py
+from python_scripts.utilities import ASpaceAPI, read_csv, write_to_file
+
+logger.remove()
+log_path = Path('../../logs', 'delete_locations_{time:YYYY-MM-DD}.log')
+logger.add(str(log_path), format="{time}-{level}: {message}")
+
+# Find  and load environment-specific .env file
+env_file = find_dotenv(f'.env.{os.getenv("ENV", "dev")}')
+load_dotenv(env_file)
+
+def parseArguments():
+    """Parses the arguments fed to the script from the terminal or within a run configuration"""
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("csvPath", help="path to CSV input file", type=str)
+    parser.add_argument("jsonPath", help="path to the JSONL file for storing data", type=str)
+    parser.add_argument("objectType", help="resources/archival_objects/digital_objects", type=str)
+    parser.add_argument("-dR", "--dry-run", help="dry run?", action='store_true')
+    parser.add_argument("--version", action="version", version='%(prog)s - Version 1.0')
+
+    return parser.parse_args()
+
+
+def main(csv_path, jsonl_path, objectType, dry_run=False):
+    """
+    This script takes a CSV of URIs and object type as inputs, grabs all the locations' JSON data using the API, saves
+    them to a jsonL file using the jsonl_path input, and then deletes them in ArchivesSpace.
+
+    The CSV should have the following data structure:
+    - Column 1 header = uri
+    - Column 1 rows = /locations/#######
+
+    Args:
+        csv_path (str): filepath of the CSV file with the location URIs
+        jsonl_path (str): filepath of the jsonL file for storing JSON data of objects before updates - backup
+        objectType (str): the type of object you want to delete. resources/archival_objects/digital_objects/locations
+        dry_run (bool): if True, it prints the changed object_json but does not post the changes to ASpace
+    """
+    local_aspace = ASpaceAPI(os.getenv('as_api'), os.getenv('as_un'), os.getenv('as_pw'))
+    for uri in read_csv(csv_path):
+        uri_parts = uri['uri'].split('/')
+        location = local_aspace.get_object(objectType, uri_parts[2])
+        write_to_file(jsonl_path, location)
+        if location:
+            if dry_run:
+                print(f'Deleted location {uri['uri']}')
+            else:
+                post_response = local_aspace.delete_object(location['uri'])
+                if post_response:
+                    print(post_response)
+
+
+# Call with `python delete_objects.py <csv_filpath>.csv <jsonl_filepath>.jsonl <object type>`
+if __name__ == '__main__':
+    args = parseArguments()
+
+    # Print arguments
+    logger.info(f'Running {sys.argv[0]} script with following arguments: ')
+    print(f'Running {sys.argv[0]} script with following arguments: ')
+    for arg in args.__dict__:
+        logger.info(str(arg) + ": " + str(args.__dict__[arg]))
+        print(str(arg) + ": " + str(args.__dict__[arg]))
+
+    # Run function
+    main(csv_path=args.csvPath, jsonl_path= args.jsonPath, objectType=args.objectType, dry_run=args.dry_run)

--- a/python_scripts/repeatable/delete_objects.py
+++ b/python_scripts/repeatable/delete_objects.py
@@ -78,7 +78,7 @@ def main(csv_path, jsonl_path, dry_run=False):
         write_to_file(jsonl_path, object_json)
         if object_json:
             if dry_run:
-                print(f'Deleted object {uri['uri']}')
+                print(f'Object would be deleted: {uri['uri']}')
             else:
                 post_response = local_aspace.delete_object(object_json['uri'])
                 if post_response:

--- a/python_scripts/repeatable/delete_objects.py
+++ b/python_scripts/repeatable/delete_objects.py
@@ -47,7 +47,7 @@ def retrieve_object_json(object_uri, local_aspace):
         uri_parts = object_uri['uri'].split('/')
         object_type, object_id = uri_parts[-2], uri_parts[-1]
     except IndexError as spliterror:
-        record_error(f'retrieve_object_json() - Failed to split URI', spliterror)
+        record_error('retrieve_object_json() - Failed to split URI', spliterror)
         return None
     else:
         if "repositories" in uri_parts:

--- a/python_scripts/utilities.py
+++ b/python_scripts/utilities.py
@@ -145,6 +145,23 @@ class ASpaceAPI:
         else:
             return suppress_message
 
+    def delete_object(self, object_uri):
+        """
+        Deletes the given object from ArchivesSpace, given the object's URI. WARNING: deletions in ArchivesSpace are
+        permanent!
+
+        Args:
+            object_uri (str): the object's URI for deletion
+
+        Returns:
+            update_message (dict): ArchivesSpace response or None if an error was encountered and logged
+        """
+        delete_message = self.aspace_client.delete(f'{object_uri}').json()
+        if 'error' in delete_message:
+            record_error('delete_object() - Delete failed due to following error', delete_message)
+        else:
+            return delete_message
+
 
 class ASpaceDatabase:
 

--- a/test_data/utilities_testdata.py
+++ b/test_data/utilities_testdata.py
@@ -310,3 +310,7 @@ test_error_json = {
     "repository": {"ref": "/repositories/20"},
     "tree": {"ref": "/repositories/20/digital_objects/3819/tree"}
 }
+
+test_location_delete = {'building': 'NMAH-SHF',
+                        'coordinate_1_label': 'Test Shelf',
+                        'coordinate_1_indicator': '602668'}

--- a/tests/deleteobject_tests.py
+++ b/tests/deleteobject_tests.py
@@ -1,0 +1,68 @@
+# This script consists of unittests for delete_object.py
+import contextlib
+import io
+import unittest
+
+from python_scripts.repeatable.delete_objects import *
+from python_scripts.utilities import *
+from test_data.utilities_testdata import *
+
+# Hardcode to dev env
+env_file = find_dotenv('.env.dev')
+load_dotenv(env_file)
+local_aspace = client_login(os.getenv('as_api'), os.getenv('as_un'), os.getenv('as_pw'))
+test_dbconnection = ASpaceDatabase(os.getenv('db_un'), os.getenv('db_pw'), os.getenv('db_host'), os.getenv('db_name'),
+                                   int(os.getenv('db_port')))
+
+
+class TestArchivesSpaceClass(unittest.TestCase):
+    good_aspace_connection = ASpaceAPI(os.getenv('as_api'), os.getenv('as_un'), os.getenv('as_pw'))
+
+    def test_global_uri(self):
+        """Tests a global URI for an object returns said objects' JSON data"""
+        test_location = self.good_aspace_connection.aspace_client.post("/locations", json=test_location_delete).json()
+        test_global = retrieve_object_json({'uri': test_location['uri']}, self.good_aspace_connection)
+        self.assertIsNotNone(test_global)
+        self.assertEqual(test_global['title'], 'NMAH-SHF [Test Shelf: 602668]')
+        test_delete = self.good_aspace_connection.delete_object(test_location['uri'])
+        print(test_delete)
+
+    def test_local_uri(self):
+        """Tests that a local URI (one beginning with 'repositories/##/' is retrieved"""
+        uri_parts = test_digital_object_dates['uri'].split('/')
+        test_digobj = self.good_aspace_connection.get_object(uri_parts[-2], uri_parts[-1], f'{uri_parts[1]}/{uri_parts[2]}')
+        if 'error' not in test_digobj:
+            get_test_digobj = retrieve_object_json({'uri': test_digobj['uri']}, self.good_aspace_connection)
+            self.assertIsNotNone(get_test_digobj)
+            self.assertEqual(get_test_digobj['digital_object_id'], 'NMAI.AC.066.ref20')
+        else:
+            test_digobj_new = self.good_aspace_connection.aspace_client.post('/repositories/12/digital_objects',
+                                                                             json=test_digital_object_dates)
+            get_test_digobj_new = retrieve_object_json({'uri': test_digobj_new['uri']}, self.good_aspace_connection)
+            self.assertIsNotNone(get_test_digobj_new)
+            self.assertEqual(get_test_digobj_new['digital_object_id'], 'NMAI.AC.066.ref20')
+
+    def test_bad_uri(self):
+        """Tests that a bad URI throws an error"""
+        test_bad_uri = {'uri': '110203/locations/%^^!!!'}
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            test_response = retrieve_object_json(test_bad_uri, self.good_aspace_connection)
+
+        self.assertTrue(
+            r"""get_object() - Unable to retrieve object with provided URI: /locations/%^^!!!: {'error': {'id': ["Wanted type Integer but got '%^^!!!'"]}}""" in f.getvalue())
+        self.assertIsNone(test_response)
+
+    def test_bad_separator(self):
+        test_bad_uri = {'uri': '110203,locations,%^^!!!'}
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            test_response = retrieve_object_json(test_bad_uri, self.good_aspace_connection)
+            print(test_response)
+        self.assertTrue(
+            r"""retrieve_object_json() - Failed to split URI: list index out of range""" in f.getvalue())
+        self.assertIsNone(test_response)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/utilities_tests.py
+++ b/tests/utilities_tests.py
@@ -150,6 +150,39 @@ class TestArchivesSpaceClass(unittest.TestCase):
         self.assertIsNone(test_response)
 
 
+    def test_good_delete(self):
+        """Tests that a given object is deleted from ArchivesSpace via no results when searching for it after
+        deletion"""
+        # first check the object exists
+        test_location = self.good_aspace_connection.aspace_client.post("/locations", json=test_location_delete).json()
+        record_type, location_id = test_location["uri"][1:].split("/")
+        if not "error" in test_location:
+            test_delete = self.good_aspace_connection.delete_object(test_location["uri"])
+            if "error" in test_delete:
+                self.fail()
+            else:
+                f = io.StringIO()
+                with contextlib.redirect_stdout(f):
+                    test_response = self.good_aspace_connection.get_object(record_type, location_id)
+
+                self.assertTrue(
+                    f'get_object() - Unable to retrieve object with provided URI: {test_location["uri"]}' in f.getvalue())
+
+                self.assertIsNone(test_response)
+
+
+    def test_bad_delete(self):
+        """Tests that the given object URI returns None with an error response"""
+        test_delete = "/repositories/1000000/resources/915534548632131"
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            test_response = self.good_aspace_connection.delete_object(test_delete)
+
+        self.assertTrue(
+            r"""delete_object() - Delete failed due to following error: {'error': {'repo_id': ['Failed validation -- The Repository must exist']}}""" in f.getvalue())
+        self.assertIsNone(test_response)
+
+
 class TestASpaceDatabaseClass(unittest.TestCase):
 
     def test_good_connection(self):

--- a/tests/utilities_tests.py
+++ b/tests/utilities_tests.py
@@ -156,7 +156,7 @@ class TestArchivesSpaceClass(unittest.TestCase):
         # first check the object exists
         test_location = self.good_aspace_connection.aspace_client.post("/locations", json=test_location_delete).json()
         record_type, location_id = test_location["uri"][1:].split("/")
-        if not "error" in test_location:
+        if "error" not in test_location:
             test_delete = self.good_aspace_connection.delete_object(test_location["uri"])
             if "error" in test_delete:
                 self.fail()


### PR DESCRIPTION
## Description
Add delete_objects.py script, which gives the ability to delete objects in ASpace provided with a CSV of all the URIs of objects to delete, a jsonl file to record the data before deletion, and the object type to delete (locations, digital_objects, archival_objects, resources, etc.). This PR also adds a delete_object() function to utilities.py, which takes the URI of an object to delete. Included are unittests for this function, as well as sample data in unittest_testdata.py.

## Related GitHub Issue
#100 

## Testing
 Included are unittests for delete_object() function, as well as sample data in unittest_testdata.py.

## Screenshot(s):
<!--- Optional screenshots of changes if relevant and helpful to reviewers -->

## Checklist

- [X] ✔️ Have you assigned at least one reviewer?
- [X] 🔗 Have you referenced any issues this PR will close?
- [X] ⬇️ Have you merged the latest upstream changes into your branch? 
- [X] 🧪 Have you added tests to cover these changes?  If not, why:

[//]: # (- [X] 🤖 Have automated checks &#40;if any&#41; passed?  If not, please explain for the reviewer:)

- [ ] 📘 Have you updated/added any relevant readmes/wiki pages/comments in the codebase?
- [X] 📚 Have you updated/added any external documentation (e.g. Confluence, AirTable, GitHub Projects)?
