### PR TITLE
Delete orphaned Digital Objects in CFCH repo #114

### DIFF
--- a/python_scripts/repeatable/delete_objects.py
+++ b/python_scripts/repeatable/delete_objects.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# This script takes a CSV of URIs as an input, grabs all the objects'JSON data using the API, saves
+# This script takes a CSV of URIs as an input, grabs all the objects' JSON data using the API, saves
 # them to a jsonL file using the jsonl_path input, and then deletes them in ArchivesSpace.
 import argparse
 import os

--- a/python_scripts/repeatable/delete_objects.py
+++ b/python_scripts/repeatable/delete_objects.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# This script takes a CSV of URIs and object type as inputs, grabs all the objects' JSON data using the API, saves
+# This script takes a CSV of URIs as an input, grabs all the objects'JSON data using the API, saves
 # them to a jsonL file using the jsonl_path input, and then deletes them in ArchivesSpace.
 import argparse
 import os
@@ -9,10 +9,8 @@ from dotenv import load_dotenv, find_dotenv
 from loguru import logger
 from pathlib import Path
 
-from python_scripts.one_time_scripts.delete_dometadata import record_error
-
 sys.path.append(os.path.dirname('python_scripts'))  # Needed to import functions from utilities.py
-from python_scripts.utilities import ASpaceAPI, read_csv, write_to_file
+from python_scripts.utilities import ASpaceAPI, record_error, read_csv, write_to_file
 
 logger.remove()
 log_path = Path('../../logs', 'delete_objects_{time:YYYY-MM-DD}.log')
@@ -57,10 +55,9 @@ def retrieve_object_json(object_uri, local_aspace):
             object_json = local_aspace.get_object(object_type, object_id)
         return object_json
 
-
 def main(csv_path, jsonl_path, dry_run=False):
     """
-    This script takes a CSV of URIs and object type as inputs, grabs all the objects' JSON data using the API, saves
+    This script takes a CSV of URIs as an input, grabs all the objects' JSON data using the API, saves
     them to a jsonL file using the jsonl_path input, and then deletes them in ArchivesSpace.
 
     The CSV should have the following data structure:
@@ -78,14 +75,16 @@ def main(csv_path, jsonl_path, dry_run=False):
         write_to_file(jsonl_path, object_json)
         if object_json:
             if dry_run:
-                print(f'Object would be deleted: {uri['uri']}')
+                message = f"Object would be deleted: {uri['uri']}"
+                print(message)
+                logger.info(message)
             else:
                 post_response = local_aspace.delete_object(object_json['uri'])
                 if post_response:
                     print(post_response)
+                    logger.info(post_response)
 
-
-# Call with `python delete_objects.py <csv_filpath>.csv <jsonl_filepath>.jsonl <object type>`
+# Call with `python delete_objects.py <csv_filpath>.csv <jsonl_filepath>.jsonl`
 if __name__ == '__main__':
     args = parseArguments()
 
@@ -97,4 +96,4 @@ if __name__ == '__main__':
         print(str(arg) + ": " + str(args.__dict__[arg]))
 
     # Run function
-    main(csv_path=args.csvPath, jsonl_path= args.jsonPath, objectType=args.objectType, dry_run=args.dry_run)
+    main(csv_path=args.csvPath, jsonl_path= args.jsonPath, dry_run=args.dry_run)

--- a/tests/deleteobject_tests.py
+++ b/tests/deleteobject_tests.py
@@ -1,6 +1,7 @@
 # This script consists of unittests for delete_object.py
 import contextlib
 import io
+import random
 import unittest
 
 from python_scripts.repeatable.delete_objects import *
@@ -11,9 +12,6 @@ from test_data.utilities_testdata import *
 env_file = find_dotenv('.env.dev')
 load_dotenv(env_file)
 local_aspace = client_login(os.getenv('as_api'), os.getenv('as_un'), os.getenv('as_pw'))
-test_dbconnection = ASpaceDatabase(os.getenv('db_un'), os.getenv('db_pw'), os.getenv('db_host'), os.getenv('db_name'),
-                                   int(os.getenv('db_port')))
-
 
 class TestArchivesSpaceClass(unittest.TestCase):
     good_aspace_connection = ASpaceAPI(os.getenv('as_api'), os.getenv('as_un'), os.getenv('as_pw'))
@@ -31,16 +29,17 @@ class TestArchivesSpaceClass(unittest.TestCase):
         """Tests that a local URI (one beginning with 'repositories/##/' is retrieved"""
         uri_parts = test_digital_object_dates['uri'].split('/')
         test_digobj = self.good_aspace_connection.get_object(uri_parts[-2], uri_parts[-1], f'{uri_parts[1]}/{uri_parts[2]}')
-        if 'error' not in test_digobj:
+        if test_digobj is not None:
             get_test_digobj = retrieve_object_json({'uri': test_digobj['uri']}, self.good_aspace_connection)
             self.assertIsNotNone(get_test_digobj)
             self.assertEqual(get_test_digobj['digital_object_id'], 'NMAI.AC.066.ref20')
         else:
+            test_digital_object_dates['digital_object_id'] = f'NMAI.AC.066.ref{random.randint(1, 100)}'
             test_digobj_new = self.good_aspace_connection.aspace_client.post('/repositories/12/digital_objects',
-                                                                             json=test_digital_object_dates)
+                                                                             json=test_digital_object_dates).json()
             get_test_digobj_new = retrieve_object_json({'uri': test_digobj_new['uri']}, self.good_aspace_connection)
             self.assertIsNotNone(get_test_digobj_new)
-            self.assertEqual(get_test_digobj_new['digital_object_id'], 'NMAI.AC.066.ref20')
+            self.assertTrue((get_test_digobj_new['digital_object_id']).startswith('NMAI.AC.066.ref'))
 
     def test_bad_uri(self):
         """Tests that a bad URI throws an error"""

--- a/tests/deleteobject_tests.py
+++ b/tests/deleteobject_tests.py
@@ -29,7 +29,7 @@ class TestArchivesSpaceClass(unittest.TestCase):
         """Tests that a local URI (one beginning with 'repositories/##/' is retrieved"""
         uri_parts = test_digital_object_dates['uri'].split('/')
         test_digobj = self.good_aspace_connection.get_object(uri_parts[-2], uri_parts[-1], f'{uri_parts[1]}/{uri_parts[2]}')
-        if test_digobj is not None:
+        if test_digobj:
             get_test_digobj = retrieve_object_json({'uri': test_digobj['uri']}, self.good_aspace_connection)
             self.assertIsNotNone(get_test_digobj)
             self.assertEqual(get_test_digobj['digital_object_id'], 'NMAI.AC.066.ref20')


### PR DESCRIPTION
## Description
This version of the repeatable script was run against a list of orphaned digital objects to be deleted for CFCH on 6/13.  This includes some additional tweaks and cleanup (e.g. removing the unused `objectType` argument, importing `record_error` from utilities instead of a one time script, etc.).  I toyed with moving the tests to run under CI, but because this currently relied on a running instance of ASpace I decided it would be better just to sweep this up in whatever the outcome for #85 is.

## Related GitHub Issue
Part of closing #114 

## Testing
Minor test tweaks just to make them able to be run locally when you don't have exactly matching records in your local test install.

## Screenshot(s):
N/a

## Checklist

- [x] ✔️ Have you assigned at least one reviewer?
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
- [x] 🤖 Have automated checks if any passed? 
- [x] 📘 Have you updated/added any relevant readmes/wiki pages/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence, AirTable, GitHub Projects)?
