### PR TITLE
Added report_sovatreeview.py and reportsovatreeview_tests.py, minor u…

### DIFF
--- a/python_scripts/one_time_scripts/delete_aaadigobjs.py
+++ b/python_scripts/one_time_scripts/delete_aaadigobjs.py
@@ -92,6 +92,8 @@ def main(csv_path, jsonl_path, dry_run=False):
         else:
             logger.info(f'Could not find an associated digital object with: {refID["refID"]}')
             print(f'Could not find an associated digital object with: {refID["refID"]}')
+    if os.path.exists(str(Path(os.getcwd(), 'aaa_delete_daos.csv'))):
+        os.remove(str(Path(os.getcwd(), 'aaa_delete_daos.csv')))
     with open('aaa_delete_daos.csv', 'w', encoding='UTF-8', newline='') as daofile:
         daowriter = csv.writer(daofile)
         daowriter.writerows(digobjs_uris)

--- a/python_scripts/one_time_scripts/report_sovatreeview.py
+++ b/python_scripts/one_time_scripts/report_sovatreeview.py
@@ -1,0 +1,130 @@
+#!/usr/bin/python3
+# This script finds resource records with a finding aid status of "Publish (sync with EDAN/SOVA)" and that have a
+# published archival object on the highest level component (c01), takes the list of EAD IDs from those resources,
+# and tests them against "https://sova.si.edu/fancytree/", seeing if they return an empty treeview in SOVA. If so, the
+# EAD ID and fancytree URL is logged in a CSV output file.
+
+import argparse
+import csv
+import os
+import requests
+import sys
+
+from dotenv import load_dotenv, find_dotenv
+from loguru import logger
+from pathlib import Path
+
+sys.path.append(os.path.dirname('python_scripts'))  # Needed to import functions from utilities.py
+from python_scripts.utilities import ASpaceDatabase
+
+logger.remove()
+log_path = Path('./logs', 'report_sovatreeview_{time:YYYY-MM-DD}.log')
+logger.add(str(log_path), format="{time}-{level}: {message}")
+
+# Find  and load environment-specific .env file
+env_file = find_dotenv(f'.env.{os.getenv("ENV", "dev")}')
+load_dotenv(env_file)
+
+def parseArguments():
+    """Parses the arguments fed to the script from the terminal or within a run configuration"""
+    parser = argparse.ArgumentParser()
+
+    # parser.add_argument("csvPath", help="path to CSV input file", type=str)
+    # parser.add_argument("jsonPath", help="path to the JSONL file for storing data", type=str)
+    parser.add_argument("-dR", "--dry-run", help="dry run?", action='store_true')
+    parser.add_argument("--version", action="version", version='%(prog)s - Version 1.0')
+
+    return parser.parse_args()
+
+def has_treeview(url):
+    """
+    Takes a treeview URL and returns True if the status code is 200 and False if anything other than 200.
+    Args:
+        url:
+
+    Returns:
+        treeview_status (bool): the treeview status, True if it has a treeview, False if not.
+    """
+    treeview_response = requests.get(url)
+    if not treeview_response.json():
+        return False
+    else:
+        return True
+
+def main(dry_run=False):
+    """
+    This script finds resource records with a finding aid status of "Publish (sync with EDAN/SOVA)" and that have a
+    published archival object on the highest level component (c01), takes the list of EAD IDs from those resources,
+    and tests them against "https://sova.si.edu/fancytree/", seeing if they return an empty treeview in SOVA. If so, the
+    EAD ID and fancytree URL is logged in a CSV output file.
+
+    The CSV output will have the following data structure:
+    - Column 1 header = ead_id
+    - Column 1 rows = aaa.bartmace
+    - Column 2 header = fancytree_url
+    - Column 2 rows = https://sova.si.edu/fancytree/aaa.bartmace
+
+    Args:
+        # csv_path (str): filepath of the CSV file with the archival object URIs
+        # jsonl_path (str): filepath of the jsonL file for storing JSON data of objects before updates - backup
+        dry_run (bool): if True, it prints the changed object_json but does not post the changes to ASpace
+    """
+    as_database = ASpaceDatabase(os.getenv('db_un'), os.getenv('db_pw'), os.getenv('db_host'), os.getenv('db_name'),
+                                 os.getenv('db_port'))
+    published_resources = ('SELECT '
+                               'res.ead_id AS eadid, res.id '
+                           'FROM '
+                               'archival_object AS ao '
+                                   'RIGHT JOIN '
+                               'resource AS res ON res.id = ao.root_record_id '
+                           'WHERE '
+                               'res.publish IS TRUE '
+                                   'AND res.finding_aid_status_id = 261446 '
+                                   'AND ao.root_record_id IS NOT NULL '
+                                   'AND ao.repo_id != 11 '
+                                   'AND ao.repo_id != 23 '
+                                   'AND ao.repo_id != 50 '
+                           'GROUP BY res.ead_id, res.id '
+                           'ORDER BY res.ead_id ASC')
+    pub_res_waos = as_database.query_database(published_resources)
+    no_treeview = [['ead_id', 'fancytree_url']]
+    no_treeview_count = 0
+    for ead_id in pub_res_waos:
+        treeview_url = "https://sova.si.edu/fancytree/" + str(ead_id[0])
+        treeview_status = has_treeview(treeview_url)
+        if treeview_status is False:
+            archival_objects = ('SELECT '
+                                'ao.ref_id '
+                                'FROM '
+                                'archival_object AS ao '
+                                'WHERE '
+                                f'ao.root_record_id = {ead_id[1]} '
+                                'AND ao.parent_id IS NULL '
+                                'AND ao.publish IS TRUE')
+            pub_aos = as_database.query_database(archival_objects)
+            if pub_aos:
+                no_treeview_count += 1
+                no_treeview.append([ead_id[0], treeview_url])
+                print(f'{ead_id[0]}, {treeview_url}')
+                logger.info(f'EAD with no fancytree response: {ead_id[0]}, {treeview_url}')
+    with open('sova_fancytree_report.csv', 'w', encoding='UTF-8', newline='') as csv_report:
+        notree_writer = csv.writer(csv_report)
+        notree_writer.writerows(no_treeview)
+        csv_report.close()
+    print(f'Total EADs without Treeview: {no_treeview_count}')
+    logger.info(f'Total EADs without Treeview: {no_treeview_count}')
+
+
+# Call with `python report_sovatreeview.py`
+if __name__ == '__main__':
+    args = parseArguments()
+
+    # Print arguments
+    logger.info(f'Running {sys.argv[0]} script with following arguments: ')
+    print(f'Running {sys.argv[0]} script with following arguments: ')
+    for arg in args.__dict__:
+        logger.info(str(arg) + ": " + str(args.__dict__[arg]))
+        print(str(arg) + ": " + str(args.__dict__[arg]))
+
+    # Run function
+    main(dry_run=args.dry_run)

--- a/tests/deleteaaadigobjs_tests.py
+++ b/tests/deleteaaadigobjs_tests.py
@@ -1,4 +1,4 @@
-# This script consists of unittests for shared utilities.py
+# This script consists of unittests for shared delete_aaadigobjs.py
 import unittest
 
 from python_scripts.one_time_scripts.delete_aaadigobjs import *

--- a/tests/reportsovatreeview_tests.py
+++ b/tests/reportsovatreeview_tests.py
@@ -1,0 +1,33 @@
+# This script consists of unittests for shared report_sovatreeview.py
+import unittest
+
+from python_scripts.one_time_scripts.delete_aaadigobjs import *
+from python_scripts.one_time_scripts.report_sovatreeview import has_treeview
+from python_scripts.utilities import *
+
+# Hardcode to dev env
+env_file = find_dotenv('.env.dev')
+load_dotenv(env_file)
+local_aspace = client_login(os.getenv('as_api'), os.getenv('as_un'), os.getenv('as_pw'))
+test_dbconnection = ASpaceDatabase(os.getenv('db_un'), os.getenv('db_pw'), os.getenv('db_host'), os.getenv('db_name'),
+                                   int(os.getenv('db_port')))
+
+
+class TestReportSovaTreeView(unittest.TestCase):
+    good_aspace_connection = ASpaceAPI(os.getenv('as_api'), os.getenv('as_un'), os.getenv('as_pw'))
+
+    def test_good_treeview(self):
+        """Tests that a good treeview URL returns True"""
+        good_treeview = "https://sova.si.edu/fancytree/aaa.bartmace"
+        treeview_status = has_treeview(good_treeview)
+        self.assertTrue(treeview_status)
+
+    def test_no_treeview(self):
+        """Tests that a treeview URL that has no treeview returns False"""
+        no_treeview = "https://sova.si.edu/fancytree/naa.3033.12"
+        treeview_status = has_treeview(no_treeview)
+        self.assertFalse(treeview_status)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
…pdate to delete_aaadigobjs.py

## Description
Adds a reporting script, report_sovatreeview.py, which collects EAD IDs with Publish = True, finding aid status = Publish (sync with EDAN/SOVA), and at least 1 archival object that is published at the c01 level, sees if it has a treeview in SOVA, and returns a CSV of any that do not. Also minor fixes for delete_aaadigobjs.py.

## Related GitHub Issue
#124 

## Testing
Unittests with reportsovatreeview_tests.py

## Screenshot(s):
<!--- Optional screenshots of changes if relevant and helpful to reviewers -->

## Checklist

- [X] ✔️ Have you assigned at least one reviewer?
- [X] 🔗 Have you referenced any issues this PR will close?
- [X] ⬇️ Have you merged the latest upstream changes into your branch? 
- [X] 🧪 Have you added tests to cover these changes?  If not, why:

[//]: # (- [ ] 🤖 Have automated checks &#40;if any&#41; passed?  If not, please explain for the reviewer:)

- [ ] 📘 Have you updated/added any relevant readmes/wiki pages/comments in the codebase?
- [X] 📚 Have you updated/added any external documentation (e.g. Confluence, AirTable, GitHub Projects)?
